### PR TITLE
Add presets for OS X 10.11 El Capitan

### DIFF
--- a/pxchfon.sty
+++ b/pxchfon.sty
@@ -862,6 +862,16 @@
   \pxcz@multiweight{HiraMinProN-W2.otf}{HiraMinProN-W3.otf}%
    {HiraMinProN-W6.otf}{HiraKakuProN-W3.otf}{HiraKakuProN-W6.otf}%
    {HiraKakuStdN-W8.otf}{HiraKakuProN-W6.otf}{HiraMaruProN-W4.otf}}
+\pxcz@declare@preset{hiragino-elcapitan-pro}{%
+  \usecmapforalphabet
+  \pxcz@multiweight{HiraMinProN-W2.otf}{:1:HiraginoSerif-W3.ttc}%
+   {:1:HiraginoSerif-W6.ttc}{:3:HiraginoSans-W3.ttc}{:3:HiraginoSans-W6.ttc}%
+   {:2:HiraginoSans-W8.ttc}{:3:HiraginoSans-W6.ttc}{:0:HiraginoSansR-W4.ttc}}
+\pxcz@declare@preset{hiragino-elcapitan-pron}{%
+  \usecmapforalphabet
+  \pxcz@multiweight{HiraMinProN-W2.otf}{:0:HiraginoSerif-W3.ttc}%
+   {:0:HiraginoSerif-W6.ttc}{:2:HiraginoSans-W3.ttc}{:2:HiraginoSans-W6.ttc}%
+   {:3:HiraginoSans-W8.ttc}{:2:HiraginoSans-W6.ttc}{:1:HiraginoSansR-W4.ttc}}
 \pxcz@declare@preset{morisawa-pro}{%
   \usecmapforalphabet
   \pxcz@multiweight{A-OTF-RyuminPro-Light.otf}{A-OTF-RyuminPro-Light.otf}%


### PR DESCRIPTION
Add new presets "hiragino-elcapitan-pro" and "hiragino-elcapitan-pron" for the new Japanese font set in OS X 10.11 El Capitan.
